### PR TITLE
chore: Decouple token auth services

### DIFF
--- a/internal/application/application_integration_test.go
+++ b/internal/application/application_integration_test.go
@@ -743,7 +743,7 @@ func TestRegisterUserJourneys(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, refreshTokenResponse)
-		assert.Equal(t, "rpc error: code = Internal desc = Invalid or expired refresh token", err.Error())
+		assert.Equal(t, "rpc error: code = InvalidArgument desc = Invalid or expired refresh token", err.Error())
 	})
 
 	t.Run("Refresh_Token_Success", func(t *testing.T) {
@@ -831,7 +831,7 @@ func TestRegisterUserJourneys(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, refreshTokenResponse)
-		assert.EqualError(t, err, "rpc error: code = Internal desc = Invalid token type")
+		assert.EqualError(t, err, "rpc error: code = InvalidArgument desc = Not a refresh token")
 	})
 
 	t.Run("Refresh_Token_Not_Listed_Error", func(t *testing.T) {
@@ -855,7 +855,7 @@ func TestRegisterUserJourneys(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, refreshTokenResponse)
-		assert.Equal(t, "rpc error: code = Internal desc = Invalid or expired refresh token", err.Error())
+		assert.Equal(t, "rpc error: code = InvalidArgument desc = Invalid or expired refresh token", err.Error())
 	})
 
 	t.Run("Forgot_Password_NotVerified_Error", func(t *testing.T) {

--- a/internal/service/mock/token_service_mock.go
+++ b/internal/service/mock/token_service_mock.go
@@ -6,13 +6,12 @@ package mock
 
 import (
 	context "context"
+	jwt "qd-authentication-api/internal/jwt"
+	model "qd-authentication-api/internal/model"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
 	primitive "go.mongodb.org/mongo-driver/bson/primitive"
-
-	jwt "qd-authentication-api/internal/jwt"
-	model "qd-authentication-api/internal/model"
 )
 
 // MockTokenServicer is a mock of TokenServicer interface.
@@ -158,16 +157,16 @@ func (mr *MockTokenServicerMockRecorder) VerifyJWTToken(ctx, refreshTokenString 
 }
 
 // VerifyResetPasswordToken mocks base method.
-func (m *MockTokenServicer) VerifyResetPasswordToken(ctx context.Context, token, userID string) (*model.Token, error) {
+func (m *MockTokenServicer) VerifyResetPasswordToken(ctx context.Context, userID, token string) (*model.Token, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifyResetPasswordToken", ctx, token, userID)
+	ret := m.ctrl.Call(m, "VerifyResetPasswordToken", ctx, userID, token)
 	ret0, _ := ret[0].(*model.Token)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // VerifyResetPasswordToken indicates an expected call of VerifyResetPasswordToken.
-func (mr *MockTokenServicerMockRecorder) VerifyResetPasswordToken(ctx, token, userID interface{}) *gomock.Call {
+func (mr *MockTokenServicerMockRecorder) VerifyResetPasswordToken(ctx, userID, token interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyResetPasswordToken", reflect.TypeOf((*MockTokenServicer)(nil).VerifyResetPasswordToken), ctx, token, userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyResetPasswordToken", reflect.TypeOf((*MockTokenServicer)(nil).VerifyResetPasswordToken), ctx, userID, token)
 }

--- a/internal/service/mock/user_service_mock.go
+++ b/internal/service/mock/user_service_mock.go
@@ -83,11 +83,12 @@ func (mr *MockUserServicerMockRecorder) RefreshToken(ctx, refreshTokenString int
 }
 
 // Register mocks base method.
-func (m *MockUserServicer) Register(ctx context.Context, email, password, firstName, lastName string, dateOfBirth *time.Time) error {
+func (m *MockUserServicer) Register(ctx context.Context, email, password, firstName, lastName string, dateOfBirth *time.Time) (*model.User, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Register", ctx, email, password, firstName, lastName, dateOfBirth)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*model.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Register indicates an expected call of Register.
@@ -108,6 +109,20 @@ func (m *MockUserServicer) ResendEmailVerification(ctx context.Context, email, e
 func (mr *MockUserServicerMockRecorder) ResendEmailVerification(ctx, email, emailVerificationToken interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResendEmailVerification", reflect.TypeOf((*MockUserServicer)(nil).ResendEmailVerification), ctx, email, emailVerificationToken)
+}
+
+// SendEmailVerification mocks base method.
+func (m *MockUserServicer) SendEmailVerification(ctx context.Context, user *model.User, emailVerificationToken string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendEmailVerification", ctx, user, emailVerificationToken)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendEmailVerification indicates an expected call of SendEmailVerification.
+func (mr *MockUserServicerMockRecorder) SendEmailVerification(ctx, user, emailVerificationToken interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendEmailVerification", reflect.TypeOf((*MockUserServicer)(nil).SendEmailVerification), ctx, user, emailVerificationToken)
 }
 
 // UpdateProfileDetails mocks base method.

--- a/internal/service/mock/user_service_mock.go
+++ b/internal/service/mock/user_service_mock.go
@@ -38,10 +38,10 @@ func (m *MockUserServicer) EXPECT() *MockUserServicerMockRecorder {
 }
 
 // Authenticate mocks base method.
-func (m *MockUserServicer) Authenticate(ctx context.Context, email, password string) (*model.AuthTokensResponse, error) {
+func (m *MockUserServicer) Authenticate(ctx context.Context, email, password string) (*model.User, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Authenticate", ctx, email, password)
-	ret0, _ := ret[0].(*model.AuthTokensResponse)
+	ret0, _ := ret[0].(*model.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -141,15 +141,15 @@ func (mr *MockUserServicerMockRecorder) UpdateProfileDetails(ctx, userID, profil
 }
 
 // VerifyEmail mocks base method.
-func (m *MockUserServicer) VerifyEmail(ctx context.Context, userID, verificationToken string) error {
+func (m *MockUserServicer) VerifyEmail(ctx context.Context, token *model.Token) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifyEmail", ctx, userID, verificationToken)
+	ret := m.ctrl.Call(m, "VerifyEmail", ctx, token)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // VerifyEmail indicates an expected call of VerifyEmail.
-func (mr *MockUserServicerMockRecorder) VerifyEmail(ctx, userID, verificationToken interface{}) *gomock.Call {
+func (mr *MockUserServicerMockRecorder) VerifyEmail(ctx, token interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyEmail", reflect.TypeOf((*MockUserServicer)(nil).VerifyEmail), ctx, userID, verificationToken)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyEmail", reflect.TypeOf((*MockUserServicer)(nil).VerifyEmail), ctx, token)
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -16,17 +16,17 @@ type Servicer interface {
 
 // Service is the implementation of the service
 type Service struct {
-	authenticationService UserServicer
-	tokenService          TokenServicer
-	passwordService       PasswordServicer
-	repository            repository.Storer
+	userService     UserServicer
+	tokenService    TokenServicer
+	passwordService PasswordServicer
+	repository      repository.Storer
 }
 
 var _ Servicer = &Service{}
 
 // GetAuthenticationService Returns the authentication service
 func (service *Service) GetAuthenticationService() UserServicer {
-	return service.authenticationService
+	return service.userService
 }
 
 // GetTokenService Returns the token service

--- a/internal/service/service_factory.go
+++ b/internal/service/service_factory.go
@@ -49,13 +49,13 @@ func (serviceFactory *Factory) CreateServiceManager(
 	if err != nil {
 		return nil, err
 	}
-	timeProvider := &util.RealTimeProvider{}
-	tokenService := NewTokenService(repository.GetTokenRepository(), jwtManager, *timeProvider)
+
 	userService := NewUserService(
 		emailService,
-		tokenService,
 		repository.GetUserRepository(),
 	)
+	timeProvider := &util.RealTimeProvider{}
+	tokenService := NewTokenService(repository.GetTokenRepository(), jwtManager, *timeProvider)
 	passwordService := NewPasswordService(
 		emailService,
 		tokenService,

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -16,12 +16,12 @@ func TestService(test *testing.T) {
 		controller := gomock.NewController(test)
 		defer controller.Finish()
 
-		authenticationServiceMock := mock.NewMockUserServicer(controller)
+		userServiceMock := mock.NewMockUserServicer(controller)
 		repositoryMock := repositoryMock.NewMockRepositoryer(controller)
 
 		service := &Service{
-			authenticationService: authenticationServiceMock,
-			repository:            repositoryMock,
+			userService: userServiceMock,
+			repository:  repositoryMock,
 		}
 
 		repositoryMock.EXPECT().Close().Return(nil)
@@ -33,8 +33,8 @@ func TestService(test *testing.T) {
 
 	test.Run("Close_Client_Nil_Error", func(test *testing.T) {
 		service := &Service{
-			authenticationService: nil,
-			repository:            nil,
+			userService: nil,
+			repository:  nil,
 		}
 
 		err := service.Close()

--- a/internal/service/token_service.go
+++ b/internal/service/token_service.go
@@ -69,7 +69,7 @@ func (service *TokenService) generateVerificationToken(
 	tokenHash, _, err := util.GenerateHash(verificationToken, false)
 	if err != nil {
 		logger.Error(err, "Error hashing verification token")
-		return nil, &Error{Message: "Error hashing verification token"}
+		return nil, fmt.Errorf("Error hashing verification token")
 	}
 	verificationTokentExpiryDate := service.timeProvider.Now().Add(VerificationTokenExpiry)
 	emailVerificationToken := &model.Token{

--- a/internal/service/token_service.go
+++ b/internal/service/token_service.go
@@ -105,7 +105,7 @@ func (service *TokenService) RemoveUsedToken(ctx context.Context, token *model.T
 	}
 	err = service.tokenRepository.Remove(ctx, token)
 	if err != nil {
-		logger.Error(err, "Error removing token")
+		logger.Error(err, "Error removing old token")
 		return &Error{Message: "Could not remove old token"}
 	}
 	return nil


### PR DESCRIPTION
Extract token service from user service and moved logic up to the grpc server interface layer.