### PR TITLE
feat: resend email without requesting jwt token

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.2
 require (
 	github.com/go-playground/validator/v10 v10.14.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
-	github.com/quadev-ltd/qd-common v0.0.46
+	github.com/quadev-ltd/qd-common v0.0.49
 	github.com/rs/zerolog v1.31.0
 	github.com/stretchr/testify v1.8.4
 	github.com/tryvium-travels/memongo v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,12 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/quadev-ltd/qd-common v0.0.46 h1:wt536HqAtWRW3Etgr6iPbIUgUx/XHV5LwtKZ1mMqBA4=
 github.com/quadev-ltd/qd-common v0.0.46/go.mod h1:sunwGB8LaO/71HhiqVdtukaDux0mDxyxrAJE0CeY7Oc=
+github.com/quadev-ltd/qd-common v0.0.47 h1:I1Jd2KBoL6hXRL+Il3VkQlY7CS7qNLOQAo61W2Wjxqs=
+github.com/quadev-ltd/qd-common v0.0.47/go.mod h1:sunwGB8LaO/71HhiqVdtukaDux0mDxyxrAJE0CeY7Oc=
+github.com/quadev-ltd/qd-common v0.0.48 h1:xDEWLLzVe3ediqxNiIDTQ3oLAJwoR/DS0IkiJgssSnI=
+github.com/quadev-ltd/qd-common v0.0.48/go.mod h1:sunwGB8LaO/71HhiqVdtukaDux0mDxyxrAJE0CeY7Oc=
+github.com/quadev-ltd/qd-common v0.0.49 h1:xJg+mpQ3OgqieLiY8jKFImMS21zUo9GWwFM7nTYTNA4=
+github.com/quadev-ltd/qd-common v0.0.49/go.mod h1:sunwGB8LaO/71HhiqVdtukaDux0mDxyxrAJE0CeY7Oc=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=

--- a/internal/grpcserver/constants.go
+++ b/internal/grpcserver/constants.go
@@ -20,6 +20,7 @@ var PublicMethods = map[string]string{
 	GetPublicKeyMethod:             "/pb_authentication.AuthenticationService/GetPublicKey",
 	RegisterMethod:                 "/pb_authentication.AuthenticationService/Register",
 	VerifyEmailMethod:              "/pb_authentication.AuthenticationService/VerifyEmail",
+	ResendEmailVerificationMethod:  "/pb_authentication.AuthenticationService/ResendEmailVerification",
 	AuthenticateMethod:             "/pb_authentication.AuthenticationService/Authenticate",
 	ForgotPasswordMethod:           "/pb_authentication.AuthenticationService/ForgotPassword",
 	ResetPasswordMethod:            "/pb_authentication.AuthenticationService/ResetPassword",
@@ -37,8 +38,7 @@ func PublicMethodsArray() []string {
 
 // AuthenticatedMethods are GRPC authenticated method routes
 var AuthenticatedMethods = map[string]string{
-	RefreshTokenMethod:            "/pb_authentication.AuthenticationService/RefreshToken",
-	ResendEmailVerificationMethod: "/pb_authentication.AuthenticationService/ResendEmailVerification",
-	GetUserProfileMethod:          "/pb_authentication.AuthenticationService/GetUserProfile",
-	UpdateUserProfileMethod:       "/pb_authentication.AuthenticationService/UpdateUserProfile",
+	RefreshTokenMethod:      "/pb_authentication.AuthenticationService/RefreshToken",
+	GetUserProfileMethod:    "/pb_authentication.AuthenticationService/GetUserProfile",
+	UpdateUserProfileMethod: "/pb_authentication.AuthenticationService/UpdateUserProfile",
 }

--- a/internal/service/user_service_test.go
+++ b/internal/service/user_service_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/golang/mock/gomock"
+	"github.com/quadev-ltd/qd-common/pb/gen/go/pb_authentication"
 	commonJWT "github.com/quadev-ltd/qd-common/pkg/jwt"
 	"github.com/quadev-ltd/qd-common/pkg/log"
 	loggerMock "github.com/quadev-ltd/qd-common/pkg/log/mock"
@@ -21,8 +22,6 @@ import (
 	"qd-authentication-api/internal/model"
 	repositoryMock "qd-authentication-api/internal/repository/mock"
 	serviceMock "qd-authentication-api/internal/service/mock"
-
-	"github.com/quadev-ltd/qd-common/pb/gen/go/pb_authentication"
 )
 
 const (
@@ -87,7 +86,7 @@ func createUserService(test *testing.T) *AuthServiceMockedParams {
 	}
 }
 
-func TestAuthenticationService(test *testing.T) {
+func TestUserService(test *testing.T) {
 	// Register
 	test.Run("Register_Success", func(test *testing.T) {
 		// Arrange


### PR DESCRIPTION
- Resend email without requesting jwt token
- Disable send functionality if user is verified already
- Return auth tokens on email verification